### PR TITLE
fixed accidental note opening and tab state

### DIFF
--- a/src/components/sidebar/note-tree-item.tsx
+++ b/src/components/sidebar/note-tree-item.tsx
@@ -62,6 +62,8 @@ export function NoteTreeItem({
   const hasChildren = children.length > 0;
 
   const [isDragging, setIsDragging] = React.useState(false);
+  // Track when drag just ended to prevent click-after-drag
+  const justDraggedRef = React.useRef(false);
 
   // Register as draggable and drop target
   React.useEffect(() => {
@@ -97,6 +99,11 @@ export function NoteTreeItem({
         },
         onDrop() {
           setIsDragging(false);
+          // Prevent click-after-drag for a short window
+          justDraggedRef.current = true;
+          setTimeout(() => {
+            justDraggedRef.current = false;
+          }, 100);
         },
       }),
 
@@ -175,19 +182,23 @@ export function NoteTreeItem({
   }, [doc.id, onToggleExpanded, onAddPageInside]);
 
   const handleClick = React.useCallback((e: React.MouseEvent) => {
+    // Don't open note if any drag is in progress or just ended
+    if (draggingId || justDraggedRef.current) return;
     if (e.metaKey) {
       openTab(doc.id);
     } else {
       openOrSelectTab(doc.id);
     }
-  }, [doc.id, openTab, openOrSelectTab]);
+  }, [doc.id, draggingId, openTab, openOrSelectTab]);
 
   const handleAuxClick = React.useCallback((e: React.MouseEvent) => {
+    // Don't open note if any drag is in progress or just ended
+    if (draggingId || justDraggedRef.current) return;
     if (e.button === 1) {
       e.preventDefault();
       openTab(doc.id);
     }
-  }, [doc.id, openTab]);
+  }, [doc.id, draggingId, openTab]);
 
   const iconNode = doc.emoji ? (
     <span className="flex h-4 w-4 shrink-0 items-center justify-center text-base leading-none">

--- a/src/components/tab-strip.tsx
+++ b/src/components/tab-strip.tsx
@@ -221,9 +221,11 @@ export function TabStrip() {
 
   const handleTabSelect = React.useCallback(
     (id: string) => {
+      // Don't select tab if a tab drag is in progress
+      if (draggingId) return;
       selectDocument(id);
     },
-    [selectDocument],
+    [draggingId, selectDocument],
   );
 
   const handleTabClose = React.useCallback(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -52,12 +52,14 @@ function Header() {
 
 function EditorArea() {
   const selectedId = useDocumentStore((s) => s.selectedId);
+  const openTabs = useDocumentStore((s) => s.openTabs);
   const documents = useDocumentStore((s) => s.documents);
   const selected = selectedId
     ? documents.find((d) => d.id === selectedId)
     : undefined;
 
-  if (!selectedId || !selected) {
+  // Only show editor if selectedId has a corresponding open tab
+  if (!selectedId || !selected || !openTabs.includes(selectedId)) {
     return (
       <main className="h-full flex-1 bg-[hsl(var(--background))] border-t-0">
         <div className="mx-auto max-w-[900px] px-8 py-10">

--- a/src/renderer/document-store.ts
+++ b/src/renderer/document-store.ts
@@ -59,15 +59,18 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
         limit: 500,
         offset: 0,
       });
-      set((state) => ({
-        documents,
-        loading: false,
-        // Keep selection if it still exists.
-        selectedId:
-          state.selectedId && documents.some((d) => d.id === state.selectedId)
-            ? state.selectedId
-            : documents[0]?.id ?? null,
-      }));
+      set((state) => {
+        // Keep selection only if it still exists AND has an open tab
+        const selectionValid =
+          state.selectedId &&
+          documents.some((d) => d.id === state.selectedId) &&
+          state.openTabs.includes(state.selectedId);
+        return {
+          documents,
+          loading: false,
+          selectedId: selectionValid ? state.selectedId : (state.openTabs[0] ?? null),
+        };
+      });
     } catch (err) {
       set({ loading: false, error: (err as Error).message });
     }


### PR DESCRIPTION
there was a bug occuring where upon dragging a note and dropping it anywhere, an almost random note state would open in the editor itself, with no active tab being shown either. fixed this issue. 