### PR TITLE
Fix editor auto-focus caused by background image updates

### DIFF
--- a/src/components/editor/nodes/image-component.tsx
+++ b/src/components/editor/nodes/image-component.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
 import { useLexicalNodeSelection } from "@lexical/react/useLexicalNodeSelection"
 import {
+  $addUpdateTag,
   $createParagraphNode,
   $getNodeByKey,
   $getSelection,
@@ -116,6 +117,7 @@ export function ImageComponent({
       const fileUrl = toImageUrl(filePath)
       setResolvedSrc(fileUrl)
       editor.update(() => {
+        $addUpdateTag('skip-selection-focus')
         const node = $getNodeByKey(nodeKey)
         if ($isImageNode(node)) node.setSrc(filePath)
       })

--- a/src/components/editor/plugins/image-plugin.tsx
+++ b/src/components/editor/plugins/image-plugin.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react"
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
 import {
+  $addUpdateTag,
   $createNodeSelection,
-  $createParagraphNode,
   $getNodeByKey,
   $getSelection,
   $isNodeSelection,
@@ -202,22 +202,16 @@ export function ImagePlugin(): null {
       COMMAND_PRIORITY_LOW,
     )
 
-    // Always ensure a paragraph exists after every image so the cursor
-    // has somewhere to land.  Also download external URL images locally.
+    // Download external URL images locally + clean up stale loading nodes.
     const removeMutationListener = editor.registerMutationListener(
       ImageNode,
       (mutations) => {
         editor.update(() => {
+          $addUpdateTag('skip-selection-focus')
           for (const [key, type] of mutations) {
             if (type === "destroyed") continue
             const node = $getNodeByKey(key)
             if (!$isImageNode(node)) continue
-
-            // Ensure trailing paragraph
-            const next = node.getNextSibling()
-            if (!next || $isImageNode(next)) {
-              node.insertAfter($createParagraphNode())
-            }
 
             // Download external URL images locally (e.g. from markdown shortcut or paste)
             if (type === "created") {


### PR DESCRIPTION
  Background editor.update() calls from image path resolution and mutation
  listeners were silently re-focusing the editor, restoring stale selections
  that caused checkbox jump-to-top when clicking without prior editor focus.