### PR TITLE
fix missing image error state and strict mode locator bugs

### DIFF
--- a/src/components/editor/nodes/image-component.tsx
+++ b/src/components/editor/nodes/image-component.tsx
@@ -136,6 +136,8 @@ export function ImageComponent({
         const node = $getNodeByKey(nodeKey)
         if ($isImageNode(node)) node.setSrc(filePath)
       })
+    }).catch(() => {
+      if (!cancelled) setHasError(true)
     })
     return () => { cancelled = true }
   }, [currentImageId, currentSrc, nodeKey, editor])


### PR DESCRIPTION
Add .catch() to images.getPath IPC call in image-component so a missing DB row shows "Failed to load image" instead of an infinite spinner. Add e2e test for orphaned image reference after DB row deletion. Scope bare .ContentEditable__root locators to main:visible to prevent strict mode violations when multiple tabs are mounted.