### PR TITLE
fixed img protocol to reject image traversal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   protocol,
 } from 'electron';
 import { closeDatabase, initDatabase } from './main/db';
+import { resolveImagePath } from './main/image-protocol';
 import { registerIpcHandlers } from './main/ipc';
 import { getSetting } from './main/repos/settings';
 
@@ -159,12 +160,16 @@ const createWindow = (): BrowserWindow => {
 app.whenReady().then(() => {
   Menu.setApplicationMenu(buildAppMenu());
 
-  // Handle lychee-image:// protocol — serves files from userData/images/
+  // Handle lychee-image:// protocol — serves files from userData/images/.
+  // resolveImagePath rejects path-traversal, absolute paths, null bytes, and
+  // malformed encoding; without it, a crafted URL could read arbitrary files.
   protocol.handle('lychee-image', (request) => {
-    // URL format: lychee-image://image/<filename>
-    const filePath = decodeURIComponent(request.url.replace('lychee-image://image/', ''));
-    const fullPath = path.join(app.getPath('userData'), 'images', filePath);
-    return net.fetch(`file://${fullPath}`);
+    const imagesDir = path.join(app.getPath('userData'), 'images');
+    const resolved = resolveImagePath(request.url, imagesDir);
+    if (!resolved.ok) {
+      return new Response(null, { status: 403 });
+    }
+    return net.fetch(`file://${resolved.path}`);
   });
 
   const { dbPath } = initDatabase();

--- a/src/main/__tests__/image-protocol.test.ts
+++ b/src/main/__tests__/image-protocol.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for resolveImagePath — the path-traversal guard for the
+ * lychee-image:// protocol handler. See GitHub issue #114.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { resolveImagePath } from '../image-protocol';
+
+const IMAGES_DIR = path.resolve('/tmp/lychee-test/images');
+
+describe('resolveImagePath — happy path', () => {
+  it('accepts a uuid-style filename', () => {
+    const r = resolveImagePath('lychee-image://image/abc-123.png', IMAGES_DIR);
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe(path.join(IMAGES_DIR, 'abc-123.png'));
+  });
+
+  it('accepts URL-encoded spaces in filenames', () => {
+    const r = resolveImagePath('lychee-image://image/my%20image.png', IMAGES_DIR);
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe(path.join(IMAGES_DIR, 'my image.png'));
+  });
+});
+
+describe('resolveImagePath — path traversal', () => {
+  it('rejects simple ../ traversal', () => {
+    expect(resolveImagePath('lychee-image://image/../etc/passwd', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects deeply nested ../ traversal', () => {
+    expect(resolveImagePath('lychee-image://image/../../../../../etc/passwd', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects URL-encoded ../ (%2e%2e)', () => {
+    expect(resolveImagePath('lychee-image://image/%2e%2e/%2e%2e/etc/passwd', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects mixed encoded/literal traversal', () => {
+    expect(resolveImagePath('lychee-image://image/foo/..%2f..%2fetc/passwd', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects traversal that resolves to imagesDir parent', () => {
+    expect(resolveImagePath('lychee-image://image/..', IMAGES_DIR).ok).toBe(false);
+  });
+});
+
+describe('resolveImagePath — absolute paths', () => {
+  it('rejects an absolute Unix path', () => {
+    expect(resolveImagePath('lychee-image://image//etc/passwd', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects a URL-encoded absolute path', () => {
+    expect(resolveImagePath('lychee-image://image/%2Fetc%2Fpasswd', IMAGES_DIR).ok).toBe(false);
+  });
+});
+
+describe('resolveImagePath — round-trip traversal', () => {
+  // ../ followed by re-entry into imagesDir resolves back inside — must accept.
+  it('accepts a path that traverses up but lands back inside imagesDir', () => {
+    const dirName = path.basename(IMAGES_DIR);
+    const r = resolveImagePath(`lychee-image://image/../${dirName}/abc.png`, IMAGES_DIR);
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe(path.join(IMAGES_DIR, 'abc.png'));
+  });
+
+  // ../ followed by re-entry into a sibling dir escapes — must reject.
+  it('rejects ../ that lands in a sibling directory', () => {
+    expect(resolveImagePath('lychee-image://image/../other/abc.png', IMAGES_DIR).ok).toBe(false);
+  });
+
+  // Multiple ../ that escape past imagesDir's parent must reject.
+  it('rejects ../ followed by absolute-looking suffix', () => {
+    expect(resolveImagePath('lychee-image://image/../../images/abc.png', IMAGES_DIR).ok).toBe(false);
+  });
+});
+
+describe('resolveImagePath — benign edge cases', () => {
+  // A literal "..." filename (3+ dots) is not a traversal marker; treat as filename.
+  it('accepts a filename consisting only of dots (e.g. "...")', () => {
+    const r = resolveImagePath('lychee-image://image/...', IMAGES_DIR);
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe(path.join(IMAGES_DIR, '...'));
+  });
+
+  // Subdirectories under imagesDir are accepted (no current code writes them,
+  // but the guard shouldn't reject a structurally valid descendant).
+  it('accepts a nested path that stays inside imagesDir', () => {
+    const r = resolveImagePath('lychee-image://image/sub/foo.png', IMAGES_DIR);
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe(path.join(IMAGES_DIR, 'sub', 'foo.png'));
+  });
+});
+
+describe('resolveImagePath — malformed input', () => {
+  it('rejects an empty filename', () => {
+    expect(resolveImagePath('lychee-image://image/', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects a path equal to imagesDir itself (".")', () => {
+    expect(resolveImagePath('lychee-image://image/.', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects null-byte injection', () => {
+    expect(resolveImagePath('lychee-image://image/foo.png%00../../etc/passwd', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects malformed URI encoding', () => {
+    expect(resolveImagePath('lychee-image://image/%E0%A4%A', IMAGES_DIR).ok).toBe(false);
+  });
+
+  it('rejects URLs with the wrong scheme/host prefix', () => {
+    expect(resolveImagePath('file:///etc/passwd', IMAGES_DIR).ok).toBe(false);
+    expect(resolveImagePath('lychee-image://other/abc.png', IMAGES_DIR).ok).toBe(false);
+  });
+});

--- a/src/main/image-protocol.ts
+++ b/src/main/image-protocol.ts
@@ -1,0 +1,35 @@
+import path from 'path';
+
+const URL_PREFIX = 'lychee-image://image/';
+
+export interface ResolvedImagePath {
+  ok: boolean;
+  path?: string;
+}
+
+/**
+ * Resolve a `lychee-image://image/<filename>` URL to an absolute filesystem path,
+ * rejecting anything that escapes `imagesDir` (path traversal, absolute paths,
+ * null-byte injection, malformed URI encoding, empty/self references).
+ */
+export function resolveImagePath(url: string, imagesDir: string): ResolvedImagePath {
+  if (!url.startsWith(URL_PREFIX)) return { ok: false };
+  const raw = url.slice(URL_PREFIX.length);
+  if (!raw) return { ok: false };
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return { ok: false };
+  }
+  if (decoded.includes('\0')) return { ok: false };
+
+  const baseDir = path.resolve(imagesDir);
+  const resolved = path.resolve(baseDir, decoded);
+
+  if (resolved === baseDir) return { ok: false };
+  if (!resolved.startsWith(baseDir + path.sep)) return { ok: false };
+
+  return { ok: true, path: resolved };
+}


### PR DESCRIPTION
fixed image path security issue. images now have to have a specific path. 