### PR TITLE
fixed bug with tab position scrolling being reset

### DIFF
--- a/e2e/tab-scroll-retention.spec.ts
+++ b/e2e/tab-scroll-retention.spec.ts
@@ -553,6 +553,493 @@ test.describe('Tab Scroll Retention — Stress', () => {
   });
 });
 
+// ── Reorder ──────────────────────────────────────────────────────────
+//
+// Dragging tabs in the strip reorders `openTabs`. Each docId in the editor
+// area renders one persistent <main>, so without a stable render order React's
+// keyed reconciler will pick one <main> to move via insertBefore on every
+// reorder. The element it picks is the doc whose old index sits BEFORE the
+// running "last placed" cursor in the new order — concretely, the active
+// tab's <main> is moved iff the active tab's drag pushes it to a HIGHER
+// index in openTabs (L→R drag of the active). insertBefore on a scrollable
+// element in Chromium resets its scrollTop to 0 — that's the user-visible
+// bug. (The per-tab cache is NOT corrupted, because Chromium does not fire
+// a scroll event for layout-driven scrollTop changes.)
+//
+// Audit invariant: with the stable-order fix in EditorArea/App.tsx removed,
+// re-running this file must produce exactly 15 failures across the four
+// Reorder describes: 4 in main Reorder + 4 bug-catching in Reorder Edge
+// Cases (round-trip, typing-after, repeat-reorder, far-caret) + all 5 in
+// Reorder Stress + both tests in Reorder Real-World (real-mouse dnd-kit
+// drag and reorder-during-sidebar-toggle). The 5 remaining Reorder Edge
+// Cases tests (scroll=0, short non-scrollable, same-index no-op,
+// inactive-tab drag, duplicates of one doc) PASS in both states by
+// design — they assert orthogonal invariants in shapes where React's
+// reconciler doesn't pick the active <main> to move (or where there is
+// no scroll to lose). Those tests are labeled "[By-design]" inline.
+
+async function reorderTabs(window: Page, fromIndex: number, toIndex: number): Promise<void> {
+  await window.evaluate(
+    (args: { from: number; to: number }) =>
+      (window as any).__documentStore.getState().reorderTabs(args.from, args.to),
+    { from: fromIndex, to: toIndex },
+  );
+  await window.waitForTimeout(200);
+}
+
+test.describe('Tab Scroll Retention — Reorder', () => {
+  // Direct repro of the user-reported bug.
+  test('active tab dragged left → right keeps its scroll position', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'Reorder L→R A');
+    await setActiveScrollTop(window, 800);
+    const scrolledA = await getScrollTop(window);
+    expect(scrolledA).toBeGreaterThan(500);
+
+    await createAndOpenNote(window, 'Reorder L→R B');
+    await setActiveScrollTop(window, 0);
+
+    // Active tab back to A at index 0, then drag it to index 1.
+    // React will move A's <main> via insertBefore — that's the bug surface.
+    await selectTab(window, tabA);
+    await reorderTabs(window, 0, 1);
+
+    // A is still active; its scroll must not have reset to 0
+    expect(Math.abs((await getScrollTop(window)) - scrolledA)).toBeLessThan(100);
+  });
+
+  // Active scrolled to bottom of a long doc, dragged right — same shape as
+  // the user's report but stresses the "near-max scroll" boundary.
+  test('active tab scrolled to bottom dragged left → right preserves bottom position', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'Reorder Bottom A', VERY_LONG_BODY);
+    const sH = await getScrollHeight(window);
+    const cH = await getClientHeight(window);
+    const bottom = Math.max(0, sH - cH - 10);
+    await setActiveScrollTop(window, bottom);
+    const scrolled = await getScrollTop(window);
+    expect(scrolled).toBeGreaterThan(0);
+
+    await createAndOpenNote(window, 'Reorder Bottom B');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+
+    await reorderTabs(window, 0, 1);
+    expect(Math.abs((await getScrollTop(window)) - scrolled)).toBeLessThan(100);
+  });
+
+  // 3-tab variant: active at index 0 dragged to the FAR right (index 2).
+  // React still moves the active <main> (lands last in new, smallest old idx).
+  test('active tab dragged across full strip (0 → end) keeps scroll', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'Reorder Far A');
+    await setActiveScrollTop(window, 650);
+    await createAndOpenNote(window, 'Reorder Far B');
+    await setActiveScrollTop(window, 0);
+    await createAndOpenNote(window, 'Reorder Far C');
+    await setActiveScrollTop(window, 0);
+
+    await selectTab(window, tabA);
+    // [A, B, C] → [B, C, A]: React moves A.
+    await reorderTabs(window, 0, 2);
+    expect(Math.abs((await getScrollTop(window)) - 650)).toBeLessThan(100);
+  });
+
+  // Active in the middle, dragged one step right.
+  test('active tab at middle dragged one slot right keeps scroll', async ({ window }) => {
+    await createAndOpenNote(window, 'Reorder Mid A');
+    await setActiveScrollTop(window, 0);
+    const { tabId: tabB } = await createAndOpenNote(window, 'Reorder Mid B');
+    await setActiveScrollTop(window, 540);
+    await createAndOpenNote(window, 'Reorder Mid C');
+    await setActiveScrollTop(window, 0);
+
+    await selectTab(window, tabB);
+    // [A, B, C] → [A, C, B]: React moves B.
+    await reorderTabs(window, 1, 2);
+    expect(Math.abs((await getScrollTop(window)) - 540)).toBeLessThan(100);
+  });
+});
+
+// ── Reorder Edge Cases ───────────────────────────────────────────────
+//
+// Tests in this describe split into two groups:
+//   • Bug-catching (fail without the fix): round-trip drag, typing after
+//     drag, repeated reorder of same active tab, reorder with far caret.
+//   • By-design invariants (pass with OR without the fix, marked below):
+//     scroll=0 / short non-scrollable / same-index no-op / inactive-tab
+//     drag / duplicates of one doc. Each of these is a case where React's
+//     reconciler does NOT pick the active <main> as the one to move (or
+//     where there is no scroll to lose), so they verify orthogonal
+//     invariants rather than acting as bug-regression guards.
+
+test.describe('Tab Scroll Retention — Reorder Edge Cases', () => {
+  // [By-design] No scroll to lose when starting at 0.
+  test('scroll exactly at 0 stays at 0 across L→R drag (not a "default")', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE Edge0 A');
+    await setActiveScrollTop(window, 500);
+    await setActiveScrollTop(window, 0); // listener saves 0
+    await createAndOpenNote(window, 'RE Edge0 B');
+    await setActiveScrollTop(window, 300);
+    await selectTab(window, tabA);
+    await reorderTabs(window, 0, 1);
+    expect(await getScrollTop(window)).toBeLessThan(50);
+  });
+
+  // [By-design] Short doc can't scroll, so nothing to lose.
+  test('short non-scrollable doc dragged L→R does not crash and stays at 0', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE Short A', SHORT_BODY);
+    await createAndOpenNote(window, 'RE Short B');
+    await setActiveScrollTop(window, 200);
+    await selectTab(window, tabA);
+    await reorderTabs(window, 0, 1);
+    expect(await getScrollTop(window)).toBe(0);
+  });
+
+  // [By-design] Same-index drag is a no-op; openTabs/uniqueDocIds unchanged.
+  test('drag from index to same index is a no-op (no scroll perturbation)', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE NoOp A');
+    await setActiveScrollTop(window, 600);
+    await createAndOpenNote(window, 'RE NoOp B');
+    await setActiveScrollTop(window, 200);
+    await selectTab(window, tabA);
+    await reorderTabs(window, 0, 0); // same-index "drag"
+    expect(Math.abs((await getScrollTop(window)) - 600)).toBeLessThan(100);
+  });
+
+  // [By-design] Reconciler moves only inactive <main>s here; active untouched.
+  test('drag of inactive tab does not perturb active tab scroll OR its cache', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE Inactive A');
+    await setActiveScrollTop(window, 600);
+    await createAndOpenNote(window, 'RE Inactive B');
+    await setActiveScrollTop(window, 200);
+    const { tabId: tabC } = await createAndOpenNote(window, 'RE Inactive C');
+    await setActiveScrollTop(window, 450);
+    // C is active. Drag B (index 1) to position 0.
+    await reorderTabs(window, 1, 0);
+    expect(Math.abs((await getScrollTop(window)) - 450)).toBeLessThan(100);
+    // A's cached scroll must still restore correctly
+    await selectTab(window, tabA);
+    expect(Math.abs((await getScrollTop(window)) - 600)).toBeLessThan(100);
+    // And C still restores on its own when revisited
+    await selectTab(window, tabC);
+    expect(Math.abs((await getScrollTop(window)) - 450)).toBeLessThan(100);
+  });
+
+  test('round-trip drag (L→R then R→L back) returns to original scroll', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE RT A');
+    await setActiveScrollTop(window, 770);
+    await createAndOpenNote(window, 'RE RT B');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+
+    await reorderTabs(window, 0, 1); // L→R
+    expect(Math.abs((await getScrollTop(window)) - 770)).toBeLessThan(100);
+    await reorderTabs(window, 1, 0); // back
+    expect(Math.abs((await getScrollTop(window)) - 770)).toBeLessThan(100);
+  });
+
+  test('typing in active tab after L→R drag continues to autoscroll/save correctly', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE Type A');
+    await setActiveScrollTop(window, 600);
+    await createAndOpenNote(window, 'RE Type B');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+    await reorderTabs(window, 0, 1);
+    // Scroll preserved
+    expect(Math.abs((await getScrollTop(window)) - 600)).toBeLessThan(100);
+    // Adjust scroll post-drag — listener must still capture it
+    await setActiveScrollTop(window, 200);
+    await createAndOpenNote(window, 'RE Type C');
+    await setActiveScrollTop(window, 800);
+    await selectTab(window, tabA);
+    expect(Math.abs((await getScrollTop(window)) - 200)).toBeLessThan(100);
+  });
+
+  test('reorder followed by another reorder of the same active tab still preserves scroll', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE Repeat A');
+    await setActiveScrollTop(window, 680);
+    await createAndOpenNote(window, 'RE Repeat B');
+    await setActiveScrollTop(window, 0);
+    await createAndOpenNote(window, 'RE Repeat C');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+
+    await reorderTabs(window, 0, 1); // A → middle
+    expect(Math.abs((await getScrollTop(window)) - 680)).toBeLessThan(100);
+    await reorderTabs(window, 1, 2); // A → end
+    expect(Math.abs((await getScrollTop(window)) - 680)).toBeLessThan(100);
+  });
+
+  // [By-design] Duplicates share one docId → uniqueDocIds unchanged → no React move.
+  test('duplicate tabs: L→R drag of one duplicate does not lose its scroll, and its sibling keeps its own', async ({ window }) => {
+    const { tabId: t1, docId } = await createAndOpenNote(window, 'RE Dup');
+    await setActiveScrollTop(window, 800);
+    const t2 = await openDuplicateTab(window, docId);
+    await selectTab(window, t2);
+    await setActiveScrollTop(window, 150);
+
+    // Duplicates share one <main>; reordering tabs of the same docId does NOT
+    // change uniqueDocIds, so React performs no move. This test still pins
+    // that scroll on the active duplicate is preserved and the per-tabId
+    // cache for the sibling remains correct.
+    await reorderTabs(window, 1, 0);
+    expect(Math.abs((await getScrollTop(window)) - 150)).toBeLessThan(100);
+    await selectTab(window, t1);
+    expect(Math.abs((await getScrollTop(window)) - 800)).toBeLessThan(100);
+  });
+
+  test('reorder while caret is on a far-away node — scroll does not drift toward caret', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RE Caret A');
+    // Click the very first paragraph (caret near top) then scroll to bottom
+    await window
+      .locator('main:not([style*="display: none"]) .ContentEditable__root p')
+      .first()
+      .click();
+    await window.waitForTimeout(100);
+    await setActiveScrollTop(window, 800);
+    const target = await getScrollTop(window);
+
+    await createAndOpenNote(window, 'RE Caret B');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+
+    // L→R drag of active. Lexical's selection-restore + insertBefore must not
+    // combine to drag scroll to the caret near the top.
+    await reorderTabs(window, 0, 1);
+    expect(Math.abs((await getScrollTop(window)) - target)).toBeLessThan(150);
+  });
+});
+
+// ── Reorder Stress ───────────────────────────────────────────────────
+
+test.describe('Tab Scroll Retention — Reorder Stress', () => {
+  test('walk active tab from index 0 all the way to end of a 5-tab strip', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RS Walk A');
+    await setActiveScrollTop(window, 760);
+    for (let i = 1; i < 5; i++) {
+      await createAndOpenNote(window, `RS Walk ${i}`);
+      await setActiveScrollTop(window, 0);
+    }
+    await selectTab(window, tabA); // ensure A is active at index 0
+
+    // Drag A one slot to the right at a time, asserting scroll after each step.
+    for (let from = 0; from < 4; from++) {
+      await reorderTabs(window, from, from + 1);
+      expect(Math.abs((await getScrollTop(window)) - 760)).toBeLessThan(100);
+    }
+  });
+
+  test('every tab in a 5-tab strip survives an L→R drag as the active tab', async ({ window }) => {
+    const tabs: { tabId: string; target: number }[] = [];
+    for (let i = 0; i < 5; i++) {
+      const { tabId } = await createAndOpenNote(window, `RS Each ${i}`);
+      const target = 200 + i * 130; // 200, 330, 460, 590, 720
+      await setActiveScrollTop(window, target);
+      tabs.push({ tabId, target });
+    }
+
+    // Promote each tab to index 0, then drag it L→R to the end.
+    for (const { tabId, target } of tabs) {
+      await selectTab(window, tabId);
+      // Find current index of tabId in openTabs
+      const fromIdx = await window.evaluate((id: string) => {
+        const s = (window as any).__documentStore.getState();
+        return s.openTabs.findIndex((t: any) => t.tabId === id);
+      }, tabId);
+      const lastIdx = (await window.evaluate(
+        () => (window as any).__documentStore.getState().openTabs.length,
+      )) - 1;
+      if (fromIdx !== lastIdx) {
+        await reorderTabs(window, fromIdx, lastIdx);
+        expect(Math.abs((await getScrollTop(window)) - target)).toBeLessThan(100);
+      }
+    }
+  });
+
+  test('10 rapid L→R drags of the same active tab (back-forth) hold scroll', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RS Rapid A');
+    await setActiveScrollTop(window, 700);
+    await createAndOpenNote(window, 'RS Rapid B');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+
+    for (let i = 0; i < 10; i++) {
+      await reorderTabs(window, 0, 1);
+      await reorderTabs(window, 1, 0);
+    }
+    expect(Math.abs((await getScrollTop(window)) - 700)).toBeLessThan(100);
+  });
+
+  test('reorder interleaved with switches preserves every scroll across 4 tabs', async ({ window }) => {
+    const tabs: { tabId: string; target: number }[] = [];
+    for (let i = 0; i < 4; i++) {
+      const { tabId } = await createAndOpenNote(window, `RS Interleave ${i}`);
+      const target = 180 + i * 170; // 180, 350, 520, 690
+      await setActiveScrollTop(window, target);
+      tabs.push({ tabId, target });
+    }
+
+    // Interleave selects and reorders, always L→R from the current active tab.
+    const program: Array<['select', number] | ['reorderActiveRight']> = [
+      ['select', 0],
+      ['reorderActiveRight'],
+      ['select', 2],
+      ['reorderActiveRight'],
+      ['select', 1],
+      ['reorderActiveRight'],
+      ['select', 3],
+      ['reorderActiveRight'],
+      ['select', 0],
+      ['reorderActiveRight'],
+    ];
+    for (const step of program) {
+      if (step[0] === 'select') {
+        await selectTab(window, tabs[step[1]].tabId);
+        expect(Math.abs((await getScrollTop(window)) - tabs[step[1]].target)).toBeLessThan(100);
+      } else {
+        const activeId = await window.evaluate(
+          () => (window as any).__documentStore.getState().selectedId as string,
+        );
+        const fromIdx = await window.evaluate((id: string) => {
+          const s = (window as any).__documentStore.getState();
+          return s.openTabs.findIndex((t: any) => t.tabId === id);
+        }, activeId);
+        const lastIdx = (await window.evaluate(
+          () => (window as any).__documentStore.getState().openTabs.length,
+        )) - 1;
+        if (fromIdx < lastIdx) {
+          await reorderTabs(window, fromIdx, fromIdx + 1);
+          const expectedTarget = tabs.find((t) => t.tabId === activeId)!.target;
+          expect(Math.abs((await getScrollTop(window)) - expectedTarget)).toBeLessThan(100);
+        }
+      }
+    }
+
+    // Final sweep — every tab's cache still resolves correctly.
+    for (const { tabId, target } of tabs) {
+      await selectTab(window, tabId);
+      expect(Math.abs((await getScrollTop(window)) - target)).toBeLessThan(100);
+    }
+  });
+
+  test('close + L→R drag combo across 5 tabs preserves remaining scrolls', async ({ window }) => {
+    const tabs: { tabId: string; target: number }[] = [];
+    for (let i = 0; i < 5; i++) {
+      const { tabId } = await createAndOpenNote(window, `RS Close+Drag ${i}`);
+      const target = 200 + i * 140;
+      await setActiveScrollTop(window, target);
+      tabs.push({ tabId, target });
+    }
+
+    // Close index 2
+    await closeTab(window, tabs[2].tabId);
+    // Now [t0, t1, t3, t4]. Active = t4 (was last). Drag it L→R is a no-op
+    // (already at end), so drag t0 to end instead.
+    await selectTab(window, tabs[0].tabId);
+    await reorderTabs(window, 0, 3); // [t1, t3, t4, t0]
+    expect(Math.abs((await getScrollTop(window)) - tabs[0].target)).toBeLessThan(100);
+
+    // Each remaining tab still restores from its cache
+    for (const idx of [0, 1, 3, 4]) {
+      await selectTab(window, tabs[idx].tabId);
+      expect(Math.abs((await getScrollTop(window)) - tabs[idx].target)).toBeLessThan(100);
+    }
+  });
+});
+
+// ── Reorder Real-World Integration ───────────────────────────────────
+//
+// Everything above invokes `store.reorderTabs` directly, which exercises the
+// reconciler path but skips dnd-kit (5px activation, dragstart state, CSS
+// transforms applied to the dragged tab). The tests below drive a real
+// mouse drag through the strip and pair the bug surface with a sidebar
+// toggle so the editor width — and therefore the scrollable height — is
+// actively changing around the reorder.
+
+/** Drag the tab matching `fromTabId` past the center of the tab matching `toTabId`. */
+async function dragTabPast(window: Page, fromTabId: string, toTabId: string): Promise<void> {
+  const source = window.locator(`[data-tab-id="${fromTabId}"]`);
+  const target = window.locator(`[data-tab-id="${toTabId}"]`);
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) throw new Error('Tab element has no bounding box');
+
+  const startX = sourceBox.x + sourceBox.width / 2;
+  const startY = sourceBox.y + sourceBox.height / 2;
+  // Aim well past the target's center so dnd-kit's closestCenter decides to swap.
+  const direction = targetBox.x > sourceBox.x ? 1 : -1;
+  const endX = targetBox.x + targetBox.width / 2 + direction * (targetBox.width / 2 + 4);
+  const endY = targetBox.y + targetBox.height / 2;
+
+  await window.mouse.move(startX, startY);
+  await window.mouse.down();
+  // Cross the 5px PointerSensor activation distance.
+  await window.mouse.move(startX + direction * 6, startY, { steps: 4 });
+  await window.waitForTimeout(60);
+  // Travel across the gap in many small steps so collision detection fires.
+  await window.mouse.move(endX, endY, { steps: 25 });
+  await window.waitForTimeout(120);
+  await window.mouse.up();
+  await window.waitForTimeout(250);
+}
+
+test.describe('Tab Scroll Retention — Reorder Real-World', () => {
+  test('real mouse drag of active tab L→R via dnd-kit preserves scroll', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RW Drag A');
+    await setActiveScrollTop(window, 760);
+    const scrolledA = await getScrollTop(window);
+    expect(scrolledA).toBeGreaterThan(500);
+
+    const { tabId: tabB } = await createAndOpenNote(window, 'RW Drag B');
+    await setActiveScrollTop(window, 0);
+
+    // Activate A, then physically drag A past B with the mouse.
+    await selectTab(window, tabA);
+    await dragTabPast(window, tabA, tabB);
+
+    // Confirm dnd-kit actually committed the reorder (sanity check on the harness).
+    const newOrder = await window.evaluate(() =>
+      (window as any).__documentStore.getState().openTabs.map((t: any) => t.tabId),
+    );
+    expect(newOrder[1]).toBe(tabA);
+
+    // A is still active; its scroll must not have reset to 0.
+    expect(Math.abs((await getScrollTop(window)) - scrolledA)).toBeLessThan(100);
+  });
+
+  test('reorder concurrent with sidebar toggle (layout shift) preserves scroll', async ({ window }) => {
+    const { tabId: tabA } = await createAndOpenNote(window, 'RW Sidebar A');
+    await setActiveScrollTop(window, 720);
+    await createAndOpenNote(window, 'RW Sidebar B');
+    await setActiveScrollTop(window, 0);
+    await selectTab(window, tabA);
+
+    // Close the sidebar — editor widens; long-line wrap recomputes scrollHeight.
+    // scrollTop may clamp, so we re-scroll to a deterministic target before the
+    // reorder so the assertion has a stable baseline.
+    await window.locator('[aria-label="Toggle sidebar"]').click();
+    await window.waitForTimeout(400);
+    await setActiveScrollTop(window, 720);
+    const baselineClosed = await getScrollTop(window);
+    expect(baselineClosed).toBeGreaterThan(500);
+
+    // L→R drag while sidebar is closed — pure reconciler-move case under a
+    // wider layout.
+    await reorderTabs(window, 0, 1);
+    expect(Math.abs((await getScrollTop(window)) - baselineClosed)).toBeLessThan(100);
+
+    // Re-open the sidebar — editor narrows mid-flight; the active tab's
+    // <main> stays the same DOM node so scroll should clamp at most, never
+    // jump to 0.
+    await window.locator('[aria-label="Toggle sidebar"]').click();
+    await window.waitForTimeout(400);
+    expect(await getScrollTop(window)).toBeGreaterThan(100);
+
+    // Reorder again with sidebar open — verify the second toggle didn't
+    // poison the cache for A.
+    await reorderTabs(window, 1, 0);
+    expect(await getScrollTop(window)).toBeGreaterThan(100);
+  });
+});
+
 // ── Listener Behavior ────────────────────────────────────────────────
 
 test.describe('Tab Scroll Retention — Listener Behavior', () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -116,18 +116,28 @@ function EditorArea() {
     return map;
   }, [documents]);
 
-  // Collect unique docIds in tab order (first occurrence wins for stable ordering).
+  // Stable docId render order, independent of openTabs order.
+  //
+  // Why: each docId renders one persistent <main> sharing a parent. Re-ordering
+  // these via React's keyed reconciler calls insertBefore on whichever <main>
+  // it picks to move (smaller-old-index that lands later in the new order),
+  // which resets that element's scrollTop in Chromium. Keeping render order
+  // stable across openTabs reorders avoids the DOM move entirely.
+  const renderOrderRef = React.useRef<string[]>([]);
   const uniqueDocIds = React.useMemo(() => {
-    const seen = new Set<string>();
-    const result: string[] = [];
+    const present = new Set<string>();
+    for (const { docId } of openTabs) present.add(docId);
+    const next = renderOrderRef.current.filter((id) => present.has(id));
+    const inNext = new Set(next);
     for (const { docId } of openTabs) {
-      if (!seen.has(docId)) {
-        seen.add(docId);
-        result.push(docId);
+      if (!inNext.has(docId)) {
+        next.push(docId);
+        inNext.add(docId);
       }
     }
-    return result;
+    return next;
   }, [openTabs]);
+  renderOrderRef.current = uniqueDocIds;
 
   const activeDocId = React.useMemo(
     () => openTabs.find((t) => t.tabId === selectedId)?.docId ?? null,


### PR DESCRIPTION
a bug occured when you moved tabs from left to right, the scroll position would reset. 